### PR TITLE
Added a `className` prop, similarly to the `id` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ import { Doughnut } from 'react-chartjs-2';
 * width: PropTypes.number,
 * height: PropTypes.number,
 * id: PropTypes.string,
+* className: PropTypes.string,
 * legend: PropTypes.object,
 * options: PropTypes.object,
 * redraw: PropTypes.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -292,7 +292,7 @@ class ChartComponent extends React.Component {
   }
 
   render() {
-    const {height, width, id} = this.props;
+    const {height, width, id, className} = this.props;
 
     return (
       <canvas
@@ -300,6 +300,7 @@ class ChartComponent extends React.Component {
         height={height}
         width={width}
         id={id}
+        className={className}
         onClick={this.handleOnClick}
       />
     );


### PR DESCRIPTION
I added support in the commonly used `className` prop.
I made it exactly the same as the `id` prop, as they both behave as "native" React props.

This is in response to [issue 287](https://github.com/jerairrest/react-chartjs-2/issues/287).