### PR TITLE
Add the `id` prop to the TypeScript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export type ChartDataFunction<T extends chartjs.ChartData> = (
 export type ChartData<T extends chartjs.ChartData> = ChartDataFunction<T> | T;
 
 export interface ChartComponentProps {
+  id?: string;
   data: ChartData<chartjs.ChartData>;
   type?: chartjs.ChartType;
   getDatasetAtEvent?(e: any): void;


### PR DESCRIPTION
Allows the `id` prop to be used in TypeScript projects.

Without this a TypeScript error like the following is generated:

```
No overload matches this call.
  Overload 1 of 2, '(props: Readonly<LinearComponentProps>): Line', gave the following error.
    Type '{ id: string; data: ...; height: number; options: ... }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Line> & Readonly<LinearComponentProps> & Readonly<...>'.
      Property 'id' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Line> & Readonly<LinearComponentProps> & Readonly<...>'.
  Overload 2 of 2, '(props: LinearComponentProps, context?: any): Line', gave the following error.
    Type '{ id: string; data: ...; height: number; options: ... }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Line> & Readonly<LinearComponentProps> & Readonly<...>'.
      Property 'id' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Line> & Readonly<LinearComponentProps> & Readonly<...>'.
```