### PR TITLE
feat(a11y): support passing aria label and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [these examples](example) for more information
   type: Chart.ChartType
   data: Chart.ChartData | (canvas: HTMLCanvasElement | null) => Chart.ChartData;
   options?: Chart.ChartOptions;
-  accessibilityOptions?: {ariaLabel: string, fallbackContent: React.ReactNode};
+  fallbackContent?: React.ReactNode;
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (dataset: Array<{}>, event: React.MouseEvent<HTMLCanvasElement>) => void;
   getElementAtEvent?: (element: [{}], event: React.MouseEvent<HTMLCanvasElement>) => void;
@@ -123,6 +123,12 @@ const data = canvas => {
 Type: `Chart.ChartOptions`
 
 The options object that is passed into the Chart.js chart ([more info](https://www.chartjs.org/docs/latest/general/options.html))
+
+### fallbackContent
+
+Type: `React.ReactNode`
+
+A fallback for when the canvas cannot be rendered. Can be used for accessible chart descriptions ([more info](https://www.chartjs.org/docs/latest/general/accessibility.html))
 
 #### plugins
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See [these examples](example) for more information
   type: Chart.ChartType
   data: Chart.ChartData | (canvas: HTMLCanvasElement | null) => Chart.ChartData;
   options?: Chart.ChartOptions;
+  accessibilityOptions?: {ariaLabel: string, fallbackContent: React.ReactNode};
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (dataset: Array<{}>, event: React.MouseEvent<HTMLCanvasElement>) => void;
   getElementAtEvent?: (element: [{}], event: React.MouseEvent<HTMLCanvasElement>) => void;

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -171,7 +171,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
           ? accessibilityOptions.ariaLabel
           : undefined
       }
-      aria-role='img'
+      role='img'
     >
       {accessibilityOptions?.fallbackContent && (
         <p>{accessibilityOptions.fallbackContent}</p>

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -26,6 +26,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     data,
     options = {},
     plugins = [],
+    accessibilityOptions,
   } = props;
 
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -165,7 +166,17 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
       className={className}
       onClick={onClick}
       data-testid='canvas'
-    />
+      aria-label={
+        accessibilityOptions?.ariaLabel
+          ? accessibilityOptions.ariaLabel
+          : undefined
+      }
+      aria-role='img'
+    >
+      {accessibilityOptions?.fallbackContent && (
+        <p>{accessibilityOptions.fallbackContent}</p>
+      )}
+    </canvas>
   );
 });
 

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -26,7 +26,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     data,
     options = {},
     plugins = [],
-    accessibilityOptions,
+    fallbackContent,
   } = props;
 
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -159,6 +159,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
 
   return (
     <canvas
+      {...props}
       height={height}
       width={width}
       ref={canvas}
@@ -166,16 +167,9 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
       className={className}
       onClick={onClick}
       data-testid='canvas'
-      aria-label={
-        accessibilityOptions?.ariaLabel
-          ? accessibilityOptions.ariaLabel
-          : undefined
-      }
       role='img'
     >
-      {accessibilityOptions?.fallbackContent && (
-        <p>{accessibilityOptions.fallbackContent}</p>
-      )}
+      {fallbackContent}
     </canvas>
   );
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import Chart from 'chart.js/auto';
-export interface AccessibilityOptions {
-  ariaLabel: string;
-  fallbackContent: React.ReactNode;
-}
-export interface Props {
+export interface Props extends React.AriaAttributes {
   id?: string;
   className?: string;
   height?: number;
@@ -13,7 +9,7 @@ export interface Props {
   type: Chart.ChartType;
   data: Chart.ChartData | ((canvas: HTMLCanvasElement) => Chart.ChartData);
   options?: Chart.ChartOptions;
-  accessibilityOptions?: AccessibilityOptions;
+  fallbackContent?: React.ReactNode;
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (
     dataset: Array<{}>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 // eslint-disable-next-line no-unused-vars
 import Chart from 'chart.js/auto';
-
+export interface AccessibilityOptions {
+  ariaLabel: string;
+  fallbackContent: React.ReactNode;
+}
 export interface Props {
   id?: string;
   className?: string;
@@ -10,6 +13,7 @@ export interface Props {
   type: Chart.ChartType;
   data: Chart.ChartData | ((canvas: HTMLCanvasElement) => Chart.ChartData);
   options?: Chart.ChartOptions;
+  accessibilityOptions?: AccessibilityOptions;
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (
     dataset: Array<{}>,


### PR DESCRIPTION
as per https://www.chartjs.org/docs/latest/general/accessibility.html

Relating to issue: https://github.com/reactchartjs/react-chartjs-2/issues/373

Solution is to allow any react node to be passed in as fallback content. This is to avoid overly coupling the feature with our specific use case. By default no change in output should be expected but the new prop object will allow passing in fallback content and an aria-label.

Set prop as an object to allow future expansion if other a11y best practices come about.