### PR TITLE
feat(a11y): support passing aria label and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [these examples](example) for more information
   type: Chart.ChartType
   data: Chart.ChartData | (canvas: HTMLCanvasElement | null) => Chart.ChartData;
   options?: Chart.ChartOptions;
-  accessibilityOptions?: {ariaLabel: string, fallbackContent: React.ReactNode};
+  fallbackContent?: React.ReactNode;
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (dataset: Array<{}>, event: React.MouseEvent<HTMLCanvasElement>) => void;
   getElementAtEvent?: (element: [{}], event: React.MouseEvent<HTMLCanvasElement>) => void;
@@ -123,6 +123,12 @@ const data = canvas => {
 Type: `Chart.ChartOptions`
 
 The options object that is passed into the Chart.js chart ([more info](https://www.chartjs.org/docs/latest/general/options.html))
+
+### fallbackContent
+
+Type: `React.ReactNode`
+
+A fallback for when the canvas cannot be rendered. Can be used for accessible chart descriptions ([more info](https://www.chartjs.org/docs/latest/general/accessibility.html))
 
 #### plugins
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ See [these examples](example) for more information
   type: Chart.ChartType
   data: Chart.ChartData | (canvas: HTMLCanvasElement | null) => Chart.ChartData;
   options?: Chart.ChartOptions;
+  accessibilityOptions?: {ariaLabel: string, fallbackContent: React.ReactNode};
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (dataset: Array<{}>, event: React.MouseEvent<HTMLCanvasElement>) => void;
   getElementAtEvent?: (element: [{}], event: React.MouseEvent<HTMLCanvasElement>) => void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-chartjs-2",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.19"

--- a/src/__tests__/chart.test.tsx
+++ b/src/__tests__/chart.test.tsx
@@ -225,10 +225,6 @@ describe('<ChartComponent />', () => {
       <ChartComponent data={oldData} options={options} type='bar' ref={ref} />
     );
 
-    // https://www.chartjs.org/docs/latest/getting-started/v3-migration.html#removal-of-private-apis
-    // const meta0 = chart.config.data.datasets[0]._meta;
-    // const meta1 = chart.config.data.datasets[1]._meta;
-
     const id = chart.id;
 
     rerender(
@@ -236,9 +232,6 @@ describe('<ChartComponent />', () => {
     );
 
     expect(chart.config.data).toMatchObject(newData);
-    // Since the incoming data was null we stopped passing along the old meta
-    // expect(meta0).not.toEqual(chart.config.data.datasets[1]._meta);
-    // expect(meta1).toEqual(chart.config.data.datasets[0]._meta);
     expect(update).toHaveBeenCalled();
     expect(chart.id).toEqual(id);
   });
@@ -292,9 +285,7 @@ describe('<ChartComponent />', () => {
       />
     );
 
-    // expect(chart.config.data).toMatchObject(newData);
     expect(originalChartDestroy).toHaveBeenCalled();
-    // expect(chart.id).not.toEqual(id);
   });
 
   it('should destroy when unmounted', () => {

--- a/src/__tests__/chart.test.tsx
+++ b/src/__tests__/chart.test.tsx
@@ -378,4 +378,36 @@ describe('<ChartComponent />', () => {
 
     expect(getElementsAtEvent).toHaveBeenCalled();
   });
+
+  it('should show fallback content if given', () => {
+    const fallback = <p data-testid='fallbackContent'>Fallback content</p>;
+    const { getByTestId } = render(
+      <ChartComponent
+        data={data}
+        options={options}
+        className='chart-example'
+        type='bar'
+        ref={ref}
+        fallbackContent={fallback}
+      />
+    );
+
+    expect(chart).toBeTruthy();
+    expect(chart.canvas).toContainElement(getByTestId('fallbackContent'));
+  });
+
+  it('should pass through aria labels to the canvas element', () => {
+    const ariaLabel = 'ARIA LABEL';
+    render(
+      <ChartComponent
+        data={data}
+        options={options}
+        type='bar'
+        ref={ref}
+        aria-label={ariaLabel}
+      />
+    );
+
+    expect(chart.canvas.getAttribute('aria-label')).toBe(ariaLabel);
+  });
 });

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -171,7 +171,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
           ? accessibilityOptions.ariaLabel
           : undefined
       }
-      aria-role='img'
+      role='img'
     >
       {accessibilityOptions?.fallbackContent && (
         <p>{accessibilityOptions.fallbackContent}</p>

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -26,6 +26,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     data,
     options = {},
     plugins = [],
+    accessibilityOptions,
   } = props;
 
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -165,7 +166,17 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
       className={className}
       onClick={onClick}
       data-testid='canvas'
-    />
+      aria-label={
+        accessibilityOptions?.ariaLabel
+          ? accessibilityOptions.ariaLabel
+          : undefined
+      }
+      aria-role='img'
+    >
+      {accessibilityOptions?.fallbackContent && (
+        <p>{accessibilityOptions.fallbackContent}</p>
+      )}
+    </canvas>
   );
 });
 

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -26,6 +26,11 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     data,
     options = {},
     plugins = [],
+    getDatasetAtEvent,
+    getElementAtEvent,
+    getElementsAtEvent,
+    fallbackContent,
+    ...rest
   } = props;
 
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -57,8 +62,6 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
 
   const onClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
     if (!chart) return;
-
-    const { getDatasetAtEvent, getElementAtEvent, getElementsAtEvent } = props;
 
     getDatasetAtEvent &&
       getDatasetAtEvent(
@@ -155,8 +158,6 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
       updateChart();
     }
   }, [props, computedData]);
-
-  const { fallbackContent, ...rest } = props;
 
   return (
     <canvas

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -26,7 +26,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     data,
     options = {},
     plugins = [],
-    accessibilityOptions,
+    fallbackContent,
   } = props;
 
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -159,6 +159,7 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
 
   return (
     <canvas
+      {...props}
       height={height}
       width={width}
       ref={canvas}
@@ -166,16 +167,9 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
       className={className}
       onClick={onClick}
       data-testid='canvas'
-      aria-label={
-        accessibilityOptions?.ariaLabel
-          ? accessibilityOptions.ariaLabel
-          : undefined
-      }
       role='img'
     >
-      {accessibilityOptions?.fallbackContent && (
-        <p>{accessibilityOptions.fallbackContent}</p>
-      )}
+      {fallbackContent}
     </canvas>
   );
 });

--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -26,7 +26,6 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     data,
     options = {},
     plugins = [],
-    fallbackContent,
   } = props;
 
   const canvas = useRef<HTMLCanvasElement>(null);
@@ -157,9 +156,11 @@ const ChartComponent = forwardRef<Chart | undefined, Props>((props, ref) => {
     }
   }, [props, computedData]);
 
+  const { fallbackContent, ...rest } = props;
+
   return (
     <canvas
-      {...props}
+      {...rest}
       height={height}
       width={width}
       ref={canvas}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import Chart from 'chart.js/auto';
-export interface AccessibilityOptions {
-  ariaLabel: string;
-  fallbackContent: React.ReactNode;
-}
-export interface Props {
+export interface Props extends React.AriaAttributes {
   id?: string;
   className?: string;
   height?: number;
@@ -13,7 +9,7 @@ export interface Props {
   type: Chart.ChartType;
   data: Chart.ChartData | ((canvas: HTMLCanvasElement) => Chart.ChartData);
   options?: Chart.ChartOptions;
-  accessibilityOptions?: AccessibilityOptions;
+  fallbackContent?: React.ReactNode;
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (
     dataset: Array<{}>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
 // eslint-disable-next-line no-unused-vars
 import Chart from 'chart.js/auto';
-
+export interface AccessibilityOptions {
+  ariaLabel: string;
+  fallbackContent: React.ReactNode;
+}
 export interface Props {
   id?: string;
   className?: string;
@@ -10,6 +13,7 @@ export interface Props {
   type: Chart.ChartType;
   data: Chart.ChartData | ((canvas: HTMLCanvasElement) => Chart.ChartData);
   options?: Chart.ChartOptions;
+  accessibilityOptions?: AccessibilityOptions;
   plugins?: Chart.PluginServiceRegistrationOptions[];
   getDatasetAtEvent?: (
     dataset: Array<{}>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 import Chart from 'chart.js/auto';
-export interface Props extends React.AriaAttributes {
+
+export interface Props extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
   id?: string;
   className?: string;
   height?: number;
@@ -23,12 +24,4 @@ export interface Props extends React.AriaAttributes {
     elements: Array<{}>,
     event: React.MouseEvent<HTMLCanvasElement>
   ) => void;
-  // generateLegend?: (
-  //   element: [{}],
-  //   event: React.MouseEvent<HTMLCanvasElement>
-  // ) => void;
-  // getElementsAtXAxis?: (
-  //   elements: Array<{}>,
-  //   event: React.MouseEvent<HTMLCanvasElement>
-  // ) => void;
 }


### PR DESCRIPTION
as per https://www.chartjs.org/docs/latest/general/accessibility.html

Relating to issue: #373

Solution is to allow any react node to be passed in as fallback content. This is to avoid overly coupling the feature with our specific use case. By default no change in output should be expected but the new prop object will allow passing in fallback content and an aria-label.

Set prop as an object to allow future expansion if other a11y best practices come about.