### PR TITLE
Fix types.ts importing the wrong types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import Chart from 'chart.js/auto';
+import Chart from './index';
 
 export interface Props extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
   id?: string;


### PR DESCRIPTION
`types.ts` was importing from JavaScript sources instead of TypeScript sources, causing WebStorm to treat props like `data` (`Chart.ChartData`) and `options` (`Chart.ChartOptions`) as `any` instead of the correct types.