### PR TITLE
import Chart as namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "react-chartjs-2",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.19"

--- a/src/__tests__/chart.test.tsx
+++ b/src/__tests__/chart.test.tsx
@@ -71,7 +71,7 @@ describe('<ChartComponent />', () => {
   });
 
   it('should pass props onto chart if data is fn', () => {
-    const dataFn = jest.fn(c => (c ? data : {}));
+    const dataFn = jest.fn(() => ({})) as Chart.ChartData<'bar'>;
 
     render(
       <ChartComponent data={dataFn} options={options} type='bar' ref={ref} />
@@ -174,7 +174,7 @@ describe('<ChartComponent />', () => {
     const oldData = {
       labels: ['red', 'blue'],
       datasets: [{ label: 'new-colors' }, { label: 'colors', data: [3, 2] }],
-    };
+    } as Chart.ChartData;
 
     const newData = {
       labels: ['red', 'blue'],
@@ -219,7 +219,7 @@ describe('<ChartComponent />', () => {
     const newData = {
       labels: ['red', 'blue'],
       datasets: [{ label: 'colors', data: [4, 5] }, { label: 'new-colors' }],
-    };
+    } as Chart.ChartData<'bar'>;
 
     const { rerender } = render(
       <ChartComponent data={oldData} options={options} type='bar' ref={ref} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import Chart from './index';
+import type * as Chart from 'chart.js';
 
 export interface Props extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
   id?: string;
@@ -11,7 +11,7 @@ export interface Props extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
   data: Chart.ChartData | ((canvas: HTMLCanvasElement) => Chart.ChartData);
   options?: Chart.ChartOptions;
   fallbackContent?: React.ReactNode;
-  plugins?: Chart.PluginServiceRegistrationOptions[];
+  plugins?: Chart.PluginOptionsByType<Chart.ChartType>;
   getDatasetAtEvent?: (
     dataset: Array<{}>,
     event: React.MouseEvent<HTMLCanvasElement>


### PR DESCRIPTION
Current behavior fails with an error

![image](https://user-images.githubusercontent.com/75169/123558281-23c74a80-d79e-11eb-8fb4-2263d44009cf.png)

Also, I saw a PR, which introduced this change. I propose a solution, which solves both webstorm and tsc issues