### PR TITLE
Add stack properties: Example Grouped Bar Chart was not grouped

### DIFF
--- a/example/src/charts/GroupedBar.js
+++ b/example/src/charts/GroupedBar.js
@@ -8,16 +8,19 @@ const data = {
       label: '# of Red Votes',
       data: [12, 19, 3, 5, 2, 3],
       backgroundColor: 'rgb(255, 99, 132)',
+      stack: 'Stack 0',
     },
     {
       label: '# of Blue Votes',
       data: [2, 3, 20, 5, 1, 4],
       backgroundColor: 'rgb(54, 162, 235)',
+      stack: 'Stack 0',
     },
     {
       label: '# of Green Votes',
       data: [3, 10, 13, 15, 22, 30],
       backgroundColor: 'rgb(75, 192, 192)',
+      stack: 'Stack 1',
     },
   ],
 };


### PR DESCRIPTION
Currently, the example of Grouped Bar Chart was not grouped.
Added stack properties according to chart.js example (https://www.chartjs.org/docs/latest/samples/bar/stacked-groups.html)


## Before

<img width="877" alt="Screen Shot 2021-08-24 at 10 51 15" src="https://user-images.githubusercontent.com/328893/130542943-d98a6a86-8c3a-45ec-a43a-73eaa3058aa5.png">


## After

<img width="958" alt="Screen Shot 2021-08-24 at 10 50 34" src="https://user-images.githubusercontent.com/328893/130542880-2b0304cc-5dec-48c8-80ad-43b3a2747ca5.png">
