### PR TITLE
Fix: Use correct syntax for options props for line chart example

### DIFF
--- a/example/src/charts/Line.js
+++ b/example/src/charts/Line.js
@@ -16,14 +16,10 @@ const data = {
 
 const options = {
   scales: {
-    yAxes: [
-      {
-        ticks: {
-          beginAtZero: true,
-        },
-      },
-    ],
-  },
+    y: {
+      beginAtZero: true
+    }
+  }
 };
 
 const LineChart = () => (


### PR DESCRIPTION
* Use updated syntax to set `beginAtZero` for y-axis for line chart example

**After change**
![Screen Shot 2021-10-06 at 4 27 09 pm](https://user-images.githubusercontent.com/1872246/136151568-6e01867b-62a1-44c8-8c2c-79221aa68be8.png)

**Before change**
![Screen Shot 2021-10-06 at 4 28 10 pm](https://user-images.githubusercontent.com/1872246/136151636-f3d85e5c-f9be-41d3-8f26-0db60d8fd41e.png)

