### PR TITLE
refactor: new target browsers

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,24 +1,24 @@
 [
   {
-    "path": "dist/index.js",
-    "limit": "2.5 KB",
+    "path": "dist/index.cjs",
+    "limit": "1.6 KB",
     "webpack": false,
     "running": false
   },
   {
-    "path": "dist/index.js",
-    "limit": "1.5 KB",
+    "path": "dist/index.cjs",
+    "limit": "900 B",
     "import": "{ Chart }"
   },
   {
     "path": "dist/index.modern.js",
-    "limit": "2.35 KB",
+    "limit": "1.5 KB",
     "webpack": false,
     "running": false
   },
   {
     "path": "dist/index.modern.js",
-    "limit": "1.5 KB",
+    "limit": "800 B",
     "import": "{ Chart }"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "react-chartjs-2",
   "version": "3.3.0",
   "description": "React components for Chart.js",
-  "sideEffects": false,
-  "main": "dist/index.js",
-  "module": "dist/index.modern.js",
-  "types": "dist/index.d.ts",
   "author": "Jeremy Ayerst",
   "homepage": "https://github.com/reactchartjs/react-chartjs-2",
   "license": "MIT",
@@ -16,6 +12,10 @@
   "bugs": {
     "url": "https://github.com/reactchartjs/react-chartjs-2/issues"
   },
+  "sideEffects": false,
+  "main": "dist/index.cjs",
+  "module": "dist/index.modern.js",
+  "types": "dist/index.d.ts",
   "keywords": [
     "chart",
     "chart-js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import pkg from './package.json';
 
 const extensions = ['.js', '.ts', '.tsx'];
 const external = _ => /node_modules/.test(_) && !/@swc\/helpers/.test(_);
-const plugins = [
+const plugins = targets => [
   nodeResolve({
     extensions,
   }),
@@ -22,7 +22,7 @@ const plugins = [
       externalHelpers: true,
     },
     env: {
-      targets: 'defaults',
+      targets,
     },
     module: {
       type: 'es6',
@@ -34,7 +34,7 @@ const plugins = [
 export default [
   {
     input: 'src/index.tsx',
-    plugins,
+    plugins: plugins('defaults, not ie 11, not ie_mob 11'),
     external,
     output: {
       file: pkg.main,
@@ -45,7 +45,7 @@ export default [
   },
   {
     input: 'src/index.tsx',
-    plugins,
+    plugins: plugins('defaults and supports es6-module'),
     external,
     output: {
       file: pkg.module,


### PR DESCRIPTION
BREAKING CHANGE: New target browsers: ie 11 dropped for regular bundle, modern bundle builds for
browsers with es6 modules support.