### PR TITLE
feat: assure redraw occurs when type changes (#1054)

### DIFF
--- a/src/chart.tsx
+++ b/src/chart.tsx
@@ -88,6 +88,13 @@ function ChartComponent<
   }, [redraw, options, data.labels, data.datasets, updateMode]);
 
   useEffect(() => {
+    if (!chartRef.current) return;
+
+    destroyChart();
+    setTimeout(renderChart);
+  }, [type]);
+
+  useEffect(() => {
     renderChart();
 
     return () => destroyChart();

--- a/test/chart.test.tsx
+++ b/test/chart.test.tsx
@@ -108,6 +108,20 @@ describe('<Chart />', () => {
     expect(chart.id).toEqual(id);
   });
 
+  it('should properly update with a new chart type', () => {
+    const newType = 'line';
+
+    const { rerender } = render(
+      <Chart data={data} options={options} type='bar' ref={ref} />
+    );
+
+    const originalChartDestroy = Object.assign({}, destroy);
+
+    rerender(<Chart data={data} options={options} type={newType} ref={ref} />);
+
+    expect(originalChartDestroy).toHaveBeenCalled();
+  });
+
   it('should properly maintain order with new data', () => {
     const oldData = {
       labels: ['red', 'blue'],


### PR DESCRIPTION
Fixes #1054 

This extra code (and test) checks to make sure that the chart is properly redrawn when the type changes. 

Chart.JS does not support on-the-fly type updates, so a redraw is required.