### PR TITLE
fix: add BarController, LineController so multitype chart sample works after build

### DIFF
--- a/sandboxes/chart/multitype/App.tsx
+++ b/sandboxes/chart/multitype/App.tsx
@@ -9,7 +9,7 @@ import {
   Legend,
   Tooltip,
   LineController,
-  BarController
+  BarController,
 } from 'chart.js';
 import { Chart } from 'react-chartjs-2';
 import faker from 'faker';

--- a/sandboxes/chart/multitype/App.tsx
+++ b/sandboxes/chart/multitype/App.tsx
@@ -8,6 +8,8 @@ import {
   LineElement,
   Legend,
   Tooltip,
+  LineController,
+  BarController
 } from 'chart.js';
 import { Chart } from 'react-chartjs-2';
 import faker from 'faker';
@@ -19,7 +21,9 @@ ChartJS.register(
   PointElement,
   LineElement,
   Legend,
-  Tooltip
+  Tooltip,
+  LineController,
+  BarController
 );
 
 const labels = ['January', 'February', 'March', 'April', 'May', 'June', 'July'];


### PR DESCRIPTION
Import and register `BarController` and `LineController` so the example works after build.

Fixes #1063. 