### PR TITLE
docs(faq): Update why-two question header

### DIFF
--- a/website/docs/faq/why-two.md
+++ b/website/docs/faq/why-two.md
@@ -2,7 +2,7 @@
 slug: /faq/why-two
 ---
 
-# Why `react-chartjs-2` has "2" in its name?
+# Why does `react-chartjs-2` have "2" in its name?
 
 Initially, this library was [created in 2016](https://github.com/reactchartjs/react-chartjs-2/commit/d8cbcb7dc050d749771c6bb1347e22ec63bdddf9#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3) as a wrapper for Chart.js v2.
 


### PR DESCRIPTION
Was reading the docs and I think the question is more readable if it titled "why _does_ the package _have_" as opposed to "why the package has". Great project, thanks!